### PR TITLE
Refactor TILE_SIZE access modifier in AwtGameWindow

### DIFF
--- a/core/src/main/java/core/windows/awt/AwtGameWindow.java
+++ b/core/src/main/java/core/windows/awt/AwtGameWindow.java
@@ -15,7 +15,7 @@ import core.rendering.WorldRenderer;
  * Satisfies OOP Requirement 1.1 (Graphics & Threads).
  */
 public class AwtGameWindow extends JFrame {
-    private static final int TILE_SIZE = 100;
+    protected static final int TILE_SIZE = 100;
     private final Grid grid;
     private final AwtRenderer awtRenderer;
     private final WorldRenderer worldRenderer;


### PR DESCRIPTION
The `TILE_SIZE` constant in the `AwtGameWindow` class has been updated to use the `protected` access modifier. This change ensures better extensibility and allows derived classes to access the constant directly.